### PR TITLE
fix: Feature flag without variants cause FunctionClause Error

### DIFF
--- a/lib/unleash.ex
+++ b/lib/unleash.ex
@@ -126,7 +126,7 @@ defmodule Unleash do
       %{enabled: false, name: "disabled"}
   """
   @spec get_variant(atom() | String.t(), map(), Variant.result()) :: Variant.result()
-  def get_variant(name, context \\ %{}, fallback \\ %{name: "disabled", enabled: false}) do
+  def get_variant(name, context \\ %{}, fallback \\ Variant.disabled()) do
     if Config.disable_client() do
       Logger.warn(fn ->
         "Client is disabled, it will only return the fallback: #{Jason.encode!(fallback)}"

--- a/lib/unleash/variant.ex
+++ b/lib/unleash/variant.ex
@@ -26,6 +26,8 @@ defmodule Unleash.Variant do
     end
   end
 
+  def select_variant(_feature, _context), do: disabled()
+
   def from_map(map) when is_map(map) do
     %__MODULE__{
       name: map["name"],
@@ -89,7 +91,7 @@ defmodule Unleash.Variant do
   defp get_context_name("sessionId"), do: :session_id
   defp get_context_name("remoteAddress"), do: :remote_address
 
-  defp disabled do
+  def disabled do
     %{
       enabled: false,
       name: "disabled",

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,7 @@
 |> Application.load()
 |> case do
   :ok -> :unleash
+  {:error, {:already_loaded, :unleash}} -> :unleash
 end
 |> Application.spec(:applications)
 |> Enum.each(fn app -> Application.ensure_all_started(app) end)

--- a/test/unleash/variant_test.exs
+++ b/test/unleash/variant_test.exs
@@ -11,6 +11,22 @@ defmodule Unleash.VariantTest do
            } == Unleash.get_variant(:disabled_variant)
   end
 
+  test "returns a disabled variant for nonexistent flag" do
+    assert %{
+             enabled: false,
+             name: "disabled",
+             payload: %{}
+           } == Unleash.get_variant(:nonexistent_flag)
+  end
+
+  test "returns a disabled variant for a flag without variants" do
+    assert %{
+             enabled: false,
+             name: "disabled",
+             payload: %{}
+           } == Unleash.get_variant(:flag_without_variants)
+  end
+
   defp start_repo(_) do
     stop_supervised(Unleash.Repo)
 
@@ -41,6 +57,18 @@ defmodule Unleash.VariantTest do
               "payload" => %{"type" => "string", "value" => "val1"}
             }
           ]
+        },
+        %{
+          "name" => "flag_without_variants",
+          "description" => "a flag with empty variants",
+          "enabled" => true,
+          "strategies" => [
+            %{
+              "name" => "default",
+              "parameters" => %{}
+            }
+          ],
+          "variants" => []
         }
       ]
     }


### PR DESCRIPTION
We were experimenting using Unleash feature variants, and we
noticed when there's not variants the Unleash client raises
an FunctionClause exception.

It can happen when:

The code that is asking for a variant is live

Then:

You're creating a new feature flag, there's a small period the
flag exists with no variants. So the exception happens.

Or you delete all variants of a feature flag for whatever
reason. The exception happens.

Expected behaviour:

It should not raise exception and instead work as the variant is
disabled.

Workarounds: You make sure the feature flag is disabled when
creating or manipulate. But it's error prone relying on the user.

Bonus: The test_helper change is for work on newer versions of Elixir,
where already started apps returns an error.
